### PR TITLE
Update to  accept a container health check

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,13 +114,12 @@ resource "aws_ecs_cluster" "cluster" {
 }
 
 module "fargate" {
-  source  = "telia-oss/ecs-fargate/aws"
-  version = "5.4.0"
-
+  source                             = "github.com/Cantara/terraform-aws-ecs-fargate?ref=22c2ab5"
   name_prefix                        = var.name_prefix
   vpc_id                             = var.vpc_id
   private_subnet_ids                 = var.private_subnet_ids
   cluster_id                         = aws_ecs_cluster.cluster.id
+  container_health_check             = var.container_health_check
   task_container_image               = var.container_image
   task_container_environment         = var.container_environment
   task_definition_cpu                = var.task_definition_cpu
@@ -132,11 +131,6 @@ module "fargate" {
   service_registry_arn               = aws_service_discovery_service.main.arn
   with_service_discovery_srv_record  = true
   wait_for_steady_state              = true
-
-  health_check = {
-    port = "traffic-port"
-    path = "/actuator/health"
-  }
 
   deployment_circuit_breaker = {
     enable   = true

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,17 @@ variable "route_settings" {
   }))
   default = []
 }
+
+variable "container_health_check" {
+  description = "An ECS TaskDefinition HealthCheck object to set in each container"
+  default     = null
+  type = object(
+    {
+      command     = list(string)
+      interval    = number
+      retries     = number
+      startPeriod = number
+      timeout     = number
+    }
+  )
+}


### PR DESCRIPTION
This updates the version of the ECS fargate module to one that accepts an optional container health check and does not create a target group if there is no associated ALB.
The healthcheck that was in this module was not used and was just a pre-requisite for the old ECS fargate module - the new version enbales the use of an ECS container health check.
Previously only if a container stopped would it be removed from the cloudmap service - this change enables a more elegant health check