### PR TITLE
Remove logging level parameter for default route

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,6 @@ resource "aws_apigatewayv2_stage" "main" {
 
   default_route_settings {
     detailed_metrics_enabled = true
-    logging_level            = "INFO"
     throttling_burst_limit   = 100
     throttling_rate_limit    = 1000
   }


### PR DESCRIPTION
The logging level parameter is only valid for Websocket connections and causes instant  drift if set on HTTP - terraform apply keeps trying to add it on every apply